### PR TITLE
Provide kwin-5.20.5-r1

### DIFF
--- a/kde-plasma/kwin/files/kwin-5.20.5-keep-focuschain-behavior-w-minimised.patch
+++ b/kde-plasma/kwin/files/kwin-5.20.5-keep-focuschain-behavior-w-minimised.patch
@@ -1,0 +1,154 @@
+From b3e9c819537cf292d9b1c4d19c5ce7adde00158e Mon Sep 17 00:00:00 2001
+From: Nate Graham <nate@kde.org>
+Date: Tue, 20 Oct 2020 14:15:46 -0600
+Subject: [PATCH] [focuschain/task switcher] Add hidden option to govern
+ repositioning minimized windows
+
+Since some people apparently liked the old behavior of moving minimized
+windows to the end of the focus chain, let's let them have it if they
+set a hidden config option:
+
+`MoveMinimizedWindowsToEndOfTabBoxFocusChain=true` in the `[TabBox]` group
+of the kwinrc file.
+
+We can add a UI for it later if needed.
+
+BUG: 427840
+FIXED-IN: 5.21
+---
+ abstract_client.cpp |  6 +++++-
+ focuschain.cpp      | 16 ++++++++++------
+ kwin.kcfg           |  3 +++
+ options.cpp         | 11 +++++++++++
+ options.h           |  6 ++++++
+ 5 files changed, 35 insertions(+), 7 deletions(-)
+
+diff --git a/abstract_client.cpp b/abstract_client.cpp
+index e44da4725..01f3081f8 100644
+--- a/abstract_client.cpp
++++ b/abstract_client.cpp
+@@ -703,7 +703,11 @@ void AbstractClient::minimize(bool avoid_animation)
+     doMinimize();
+ 
+     updateWindowRules(Rules::Minimize);
+-    FocusChain::self()->update(this, FocusChain::MakeFirstMinimized);
++
++    if (options->moveMinimizedWindowsToEndOfTabBoxFocusChain()) {
++        FocusChain::self()->update(this, FocusChain::MakeFirstMinimized);
++    }
++
+     // TODO: merge signal with s_minimized
+     addWorkspaceRepaint(visibleRect());
+     emit clientMinimized(this, !avoid_animation);
+diff --git a/focuschain.cpp b/focuschain.cpp
+index a68e6d3c6..347df3066 100644
+--- a/focuschain.cpp
++++ b/focuschain.cpp
+@@ -227,14 +227,18 @@ AbstractClient *FocusChain::nextForDesktop(AbstractClient *reference, uint deskt
+ void FocusChain::makeFirstInChain(AbstractClient *client, Chain &chain)
+ {
+     chain.removeAll(client);
+-    if (client->isMinimized()) { // add it before the first minimized ...
+-        for (int i = chain.count()-1; i >= 0; --i) {
+-            if (chain.at(i)->isMinimized()) {
+-                chain.insert(i+1, client);
+-                return;
++    if (options->moveMinimizedWindowsToEndOfTabBoxFocusChain()) {
++        if (client->isMinimized()) { // add it before the first minimized ...
++            for (int i = chain.count()-1; i >= 0; --i) {
++                if (chain.at(i)->isMinimized()) {
++                    chain.insert(i+1, client);
++                    return;
++                }
+             }
++            chain.prepend(client); // ... or at end of chain
++        } else {
++            chain.append(client);
+         }
+-        chain.prepend(client); // ... or at end of chain
+     } else {
+         chain.append(client);
+     }
+diff --git a/kwin.kcfg b/kwin.kcfg
+index 0b59606e3..2b06efe52 100644
+--- a/kwin.kcfg
++++ b/kwin.kcfg
+@@ -295,6 +295,9 @@
+         <entry name="LayoutName" type="String">
+             <default>thumbnails</default>
+         </entry>
++        <entry name="MoveMinimizedWindowsToEndOfTabBoxFocusChain" type="Bool">
++            <default>false</default>
++        </entry>
+     </group>
+     <group name="KDE">
+         <entry name="AnimationDurationFactor" type="Double">
+diff --git a/options.cpp b/options.cpp
+index 4bce7ee39..8014f8b78 100644
+--- a/options.cpp
++++ b/options.cpp
+@@ -111,6 +111,7 @@ Options::Options(QObject *parent)
+     , m_glPreferBufferSwap(Options::defaultGlPreferBufferSwap())
+     , m_glPlatformInterface(Options::defaultGlPlatformInterface())
+     , m_windowsBlockCompositing(true)
++    , m_MoveMinimizedWindowsToEndOfTabBoxFocusChain(false)
+     , OpTitlebarDblClick(Options::defaultOperationTitlebarDblClick())
+     , CmdActiveTitlebar1(Options::defaultCommandActiveTitlebar1())
+     , CmdActiveTitlebar2(Options::defaultCommandActiveTitlebar2())
+@@ -679,6 +680,15 @@ void Options::setWindowsBlockCompositing(bool value)
+     emit windowsBlockCompositingChanged();
+ }
+ 
++void Options::setMoveMinimizedWindowsToEndOfTabBoxFocusChain(bool value)
++{
++    if (m_MoveMinimizedWindowsToEndOfTabBoxFocusChain == value) {
++        return;
++    }
++    m_MoveMinimizedWindowsToEndOfTabBoxFocusChain = value;
++
++}
++
+ void Options::setGlPreferBufferSwap(char glPreferBufferSwap)
+ {
+     if (glPreferBufferSwap == 'a') {
+@@ -849,6 +859,7 @@ void Options::syncFromKcfgc()
+     setElectricBorderTiling(m_settings->electricBorderTiling());
+     setElectricBorderCornerRatio(m_settings->electricBorderCornerRatio());
+     setWindowsBlockCompositing(m_settings->windowsBlockCompositing());
++    setMoveMinimizedWindowsToEndOfTabBoxFocusChain(m_settings->moveMinimizedWindowsToEndOfTabBoxFocusChain());
+ 
+ }
+ 
+diff --git a/options.h b/options.h
+index 6d72017d3..0834f314e 100644
+--- a/options.h
++++ b/options.h
+@@ -590,6 +590,10 @@ public:
+         return m_windowsBlockCompositing;
+     }
+ 
++    bool moveMinimizedWindowsToEndOfTabBoxFocusChain() const {
++        return m_MoveMinimizedWindowsToEndOfTabBoxFocusChain;
++    }
++
+     QStringList modifierOnlyDBusShortcut(Qt::KeyboardModifier mod) const;
+ 
+     // setters
+@@ -651,6 +655,7 @@ public:
+     void setGlPreferBufferSwap(char glPreferBufferSwap);
+     void setGlPlatformInterface(OpenGLPlatformInterface interface);
+     void setWindowsBlockCompositing(bool set);
++    void setMoveMinimizedWindowsToEndOfTabBoxFocusChain(bool set);
+ 
+     // default values
+     static WindowOperation defaultOperationTitlebarDblClick() {
+@@ -881,6 +886,7 @@ private:
+     GlSwapStrategy m_glPreferBufferSwap;
+     OpenGLPlatformInterface m_glPlatformInterface;
+     bool m_windowsBlockCompositing;
++    bool m_MoveMinimizedWindowsToEndOfTabBoxFocusChain;
+ 
+     WindowOperation OpTitlebarDblClick;
+     WindowOperation opMaxButtonRightClick = defaultOperationMaxButtonRightClick();
+-- 
+GitLab

--- a/kde-plasma/kwin/files/kwin-5.20.5-revert-new-focuschain-w-minimised.patch
+++ b/kde-plasma/kwin/files/kwin-5.20.5-revert-new-focuschain-w-minimised.patch
@@ -1,0 +1,65 @@
+From 75fded6f11ed645b0e25bf42b05fa57b8a675197 Mon Sep 17 00:00:00 2001
+From: Nate Graham <nate@kde.org>
+Date: Tue, 20 Oct 2020 14:05:33 -0600
+Subject: [PATCH] Revert "[focuschain/task switcher] Remove special handling
+ for minimized windows"
+
+This reverts commit cc862fa674d3407f516a89b8543acea04aa8b37d.
+
+It turns out that some people like this behavior and we've received
+various user complaints about it.
+---
+ abstract_client.cpp |  1 +
+ focuschain.cpp      | 12 +++++++++++-
+ focuschain.h        |  3 ++-
+ 3 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/abstract_client.cpp b/abstract_client.cpp
+index 35b7fcb61..e44da4725 100644
+--- a/abstract_client.cpp
++++ b/abstract_client.cpp
+@@ -703,6 +703,7 @@ void AbstractClient::minimize(bool avoid_animation)
+     doMinimize();
+ 
+     updateWindowRules(Rules::Minimize);
++    FocusChain::self()->update(this, FocusChain::MakeFirstMinimized);
+     // TODO: merge signal with s_minimized
+     addWorkspaceRepaint(visibleRect());
+     emit clientMinimized(this, !avoid_animation);
+diff --git a/focuschain.cpp b/focuschain.cpp
+index 66d209709..a68e6d3c6 100644
+--- a/focuschain.cpp
++++ b/focuschain.cpp
+@@ -227,7 +227,17 @@ AbstractClient *FocusChain::nextForDesktop(AbstractClient *reference, uint deskt
+ void FocusChain::makeFirstInChain(AbstractClient *client, Chain &chain)
+ {
+     chain.removeAll(client);
+-    chain.append(client);
++    if (client->isMinimized()) { // add it before the first minimized ...
++        for (int i = chain.count()-1; i >= 0; --i) {
++            if (chain.at(i)->isMinimized()) {
++                chain.insert(i+1, client);
++                return;
++            }
++        }
++        chain.prepend(client); // ... or at end of chain
++    } else {
++        chain.append(client);
++    }
+ }
+ 
+ void FocusChain::makeLastInChain(AbstractClient *client, Chain &chain)
+diff --git a/focuschain.h b/focuschain.h
+index 8baf3ea32..9a7c7e25d 100644
+--- a/focuschain.h
++++ b/focuschain.h
+@@ -41,7 +41,8 @@ class FocusChain : public QObject
+     enum Change {
+         MakeFirst,
+         MakeLast,
+-        Update
++        Update,
++        MakeFirstMinimized = MakeFirst
+     };
+     ~FocusChain() override;
+     /**

--- a/kde-plasma/kwin/files/kwin-lowlatency-5.20.5-keep-focuschain-behavior-w-minimised.patch
+++ b/kde-plasma/kwin/files/kwin-lowlatency-5.20.5-keep-focuschain-behavior-w-minimised.patch
@@ -1,0 +1,155 @@
+From 79b781a02c6bc24dbcc74ac9a82bf987b1dd5a23 Mon Sep 17 00:00:00 2001
+From: Nate Graham <nate@kde.org>
+Date: Tue, 20 Oct 2020 14:15:46 -0600
+Subject: [PATCH 2/2] [focuschain/task switcher] Add hidden option to govern
+ repositioning minimized windows
+
+Since some people apparently liked the old behavior of moving minimized
+windows to the end of the focus chain, let's let them have it if they
+set a hidden config option:
+
+`MoveMinimizedWindowsToEndOfTabBoxFocusChain=true` in the `[TabBox]` group
+of the kwinrc file.
+
+We can add a UI for it later if needed.
+
+BUG: 427840
+FIXED-IN: 5.21
+---
+ abstract_client.cpp |  6 +++++-
+ focuschain.cpp      | 16 ++++++++++------
+ kwin.kcfg           |  3 +++
+ options.cpp         | 11 +++++++++++
+ options.h           |  6 ++++++
+ 5 files changed, 35 insertions(+), 7 deletions(-)
+
+diff --git a/abstract_client.cpp b/abstract_client.cpp
+index c3b727592..69e70f7d8 100644
+--- a/abstract_client.cpp
++++ b/abstract_client.cpp
+@@ -703,7 +703,11 @@ void AbstractClient::minimize(bool avoid_animation)
+     doMinimize();
+ 
+     updateWindowRules(Rules::Minimize);
+-    FocusChain::self()->update(this, FocusChain::MakeFirstMinimized);
++
++    if (options->moveMinimizedWindowsToEndOfTabBoxFocusChain()) {
++        FocusChain::self()->update(this, FocusChain::MakeFirstMinimized);
++    }
++
+     // TODO: merge signal with s_minimized
+     addWorkspaceRepaint(visibleRect());
+     emit clientMinimized(this, !avoid_animation);
+diff --git a/focuschain.cpp b/focuschain.cpp
+index a68e6d3c6..347df3066 100644
+--- a/focuschain.cpp
++++ b/focuschain.cpp
+@@ -227,14 +227,18 @@ AbstractClient *FocusChain::nextForDesktop(AbstractClient *reference, uint deskt
+ void FocusChain::makeFirstInChain(AbstractClient *client, Chain &chain)
+ {
+     chain.removeAll(client);
+-    if (client->isMinimized()) { // add it before the first minimized ...
+-        for (int i = chain.count()-1; i >= 0; --i) {
+-            if (chain.at(i)->isMinimized()) {
+-                chain.insert(i+1, client);
+-                return;
++    if (options->moveMinimizedWindowsToEndOfTabBoxFocusChain()) {
++        if (client->isMinimized()) { // add it before the first minimized ...
++            for (int i = chain.count()-1; i >= 0; --i) {
++                if (chain.at(i)->isMinimized()) {
++                    chain.insert(i+1, client);
++                    return;
++                }
+             }
++            chain.prepend(client); // ... or at end of chain
++        } else {
++            chain.append(client);
+         }
+-        chain.prepend(client); // ... or at end of chain
+     } else {
+         chain.append(client);
+     }
+diff --git a/kwin.kcfg b/kwin.kcfg
+index 9afc7e56c..dc54f928b 100644
+--- a/kwin.kcfg
++++ b/kwin.kcfg
+@@ -323,6 +323,9 @@
+         <entry name="LayoutName" type="String">
+             <default>thumbnails</default>
+         </entry>
++        <entry name="MoveMinimizedWindowsToEndOfTabBoxFocusChain" type="Bool">
++            <default>false</default>
++        </entry>
+     </group>
+     <group name="KDE">
+         <entry name="AnimationDurationFactor" type="Double">
+diff --git a/options.cpp b/options.cpp
+index 5ef31dc91..b235803b6 100644
+--- a/options.cpp
++++ b/options.cpp
+@@ -122,6 +122,7 @@ Options::Options(QObject *parent)
+     , m_maxLatency(Options::defaultMaxLatency())
+     , m_minLatency(Options::defaultMinLatency())
+     , m_vsyncMechanism(Options::defaultVsyncMechanism())
++    , m_MoveMinimizedWindowsToEndOfTabBoxFocusChain(false)
+     , OpTitlebarDblClick(Options::defaultOperationTitlebarDblClick())
+     , CmdActiveTitlebar1(Options::defaultCommandActiveTitlebar1())
+     , CmdActiveTitlebar2(Options::defaultCommandActiveTitlebar2())
+@@ -744,6 +745,15 @@ void Options::setVsyncMechanism(int val) {
+   emit vsyncMechanismChanged();
+ }
+ 
++void Options::setMoveMinimizedWindowsToEndOfTabBoxFocusChain(bool value)
++{
++    if (m_MoveMinimizedWindowsToEndOfTabBoxFocusChain == value) {
++        return;
++    }
++    m_MoveMinimizedWindowsToEndOfTabBoxFocusChain = value;
++
++}
++
+ void Options::setGlPreferBufferSwap(char glPreferBufferSwap)
+ {
+     if (glPreferBufferSwap == 'a') {
+@@ -914,6 +924,7 @@ void Options::syncFromKcfgc()
+     setElectricBorderTiling(m_settings->electricBorderTiling());
+     setElectricBorderCornerRatio(m_settings->electricBorderCornerRatio());
+     setWindowsBlockCompositing(m_settings->windowsBlockCompositing());
++    setMoveMinimizedWindowsToEndOfTabBoxFocusChain(m_settings->moveMinimizedWindowsToEndOfTabBoxFocusChain());
+ 
+     setAnimationCurve(m_settings->animationCurve());
+     setLatencyControl(m_settings->latencyControl());
+diff --git a/options.h b/options.h
+index 3d7e1e520..b92ddaf64 100644
+--- a/options.h
++++ b/options.h
+@@ -609,6 +609,10 @@ public:
+     }
+ 
+ 
++    bool moveMinimizedWindowsToEndOfTabBoxFocusChain() const {
++        return m_MoveMinimizedWindowsToEndOfTabBoxFocusChain;
++    }
++
+     QStringList modifierOnlyDBusShortcut(Qt::KeyboardModifier mod) const;
+ 
+     // setters
+@@ -676,6 +680,7 @@ public:
+     void setMaxLatency(int val);
+     void setMinLatency(int val);
+     void setVsyncMechanism(int val);
++    void setMoveMinimizedWindowsToEndOfTabBoxFocusChain(bool set);
+ 
+     // default values
+     static WindowOperation defaultOperationTitlebarDblClick() {
+@@ -936,6 +941,7 @@ private:
+     int m_maxLatency;
+     int m_minLatency;
+     int m_vsyncMechanism;
++    bool m_MoveMinimizedWindowsToEndOfTabBoxFocusChain;
+ 
+     WindowOperation OpTitlebarDblClick;
+     WindowOperation opMaxButtonRightClick = defaultOperationMaxButtonRightClick();
+-- 
+2.30.0
+

--- a/kde-plasma/kwin/files/kwin-lowlatency-5.20.5-revert-new-focuschain-w-minimised.patch
+++ b/kde-plasma/kwin/files/kwin-lowlatency-5.20.5-revert-new-focuschain-w-minimised.patch
@@ -1,0 +1,68 @@
+From f18b2c051a18432f0bc95e90c3251ac6554d997f Mon Sep 17 00:00:00 2001
+From: Nate Graham <nate@kde.org>
+Date: Tue, 20 Oct 2020 14:05:33 -0600
+Subject: [PATCH 1/2] Revert "[focuschain/task switcher] Remove special
+ handling for minimized windows"
+
+This reverts commit cc862fa674d3407f516a89b8543acea04aa8b37d.
+
+It turns out that some people like this behavior and we've received
+various user complaints about it.
+---
+ abstract_client.cpp |  1 +
+ focuschain.cpp      | 12 +++++++++++-
+ focuschain.h        |  3 ++-
+ 3 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/abstract_client.cpp b/abstract_client.cpp
+index 2984f67f0..c3b727592 100644
+--- a/abstract_client.cpp
++++ b/abstract_client.cpp
+@@ -703,6 +703,7 @@ void AbstractClient::minimize(bool avoid_animation)
+     doMinimize();
+ 
+     updateWindowRules(Rules::Minimize);
++    FocusChain::self()->update(this, FocusChain::MakeFirstMinimized);
+     // TODO: merge signal with s_minimized
+     addWorkspaceRepaint(visibleRect());
+     emit clientMinimized(this, !avoid_animation);
+diff --git a/focuschain.cpp b/focuschain.cpp
+index 66d209709..a68e6d3c6 100644
+--- a/focuschain.cpp
++++ b/focuschain.cpp
+@@ -227,7 +227,17 @@ AbstractClient *FocusChain::nextForDesktop(AbstractClient *reference, uint deskt
+ void FocusChain::makeFirstInChain(AbstractClient *client, Chain &chain)
+ {
+     chain.removeAll(client);
+-    chain.append(client);
++    if (client->isMinimized()) { // add it before the first minimized ...
++        for (int i = chain.count()-1; i >= 0; --i) {
++            if (chain.at(i)->isMinimized()) {
++                chain.insert(i+1, client);
++                return;
++            }
++        }
++        chain.prepend(client); // ... or at end of chain
++    } else {
++        chain.append(client);
++    }
+ }
+ 
+ void FocusChain::makeLastInChain(AbstractClient *client, Chain &chain)
+diff --git a/focuschain.h b/focuschain.h
+index 8baf3ea32..9a7c7e25d 100644
+--- a/focuschain.h
++++ b/focuschain.h
+@@ -41,7 +41,8 @@ public:
+     enum Change {
+         MakeFirst,
+         MakeLast,
+-        Update
++        Update,
++        MakeFirstMinimized = MakeFirst
+     };
+     ~FocusChain() override;
+     /**
+-- 
+2.30.0
+

--- a/kde-plasma/kwin/kwin-5.20.5-r1.ebuild
+++ b/kde-plasma/kwin/kwin-5.20.5-r1.ebuild
@@ -1,0 +1,138 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+ECM_HANDBOOK="optional"
+ECM_TEST="optional"
+KFMIN=5.74.0
+PVCUT=$(ver_cut 1-3)
+QTMIN=5.15.1
+VIRTUALX_REQUIRED="test"
+inherit ecm kde.org
+
+DESCRIPTION="Flexible, composited Window Manager for windowing systems on Linux"
+
+LICENSE="GPL-2+"
+SLOT="5"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+IUSE="accessibility caps gles2-only lowlatency multimedia screencast"
+
+RESTRICT+=" test"
+
+COMMON_DEPEND="
+	>=dev-libs/libinput-1.14
+	>=dev-libs/wayland-1.2
+	>=dev-qt/qtdbus-${QTMIN}:5
+	>=dev-qt/qtdeclarative-${QTMIN}:5
+	>=dev-qt/qtgui-${QTMIN}:5=[gles2-only=]
+	>=dev-qt/qtscript-${QTMIN}:5
+	>=dev-qt/qtsensors-${QTMIN}:5
+	>=dev-qt/qtwidgets-${QTMIN}:5
+	>=dev-qt/qtx11extras-${QTMIN}:5
+	>=kde-frameworks/kactivities-${KFMIN}:5
+	>=kde-frameworks/kauth-${KFMIN}:5
+	>=kde-frameworks/kcmutils-${KFMIN}:5
+	>=kde-frameworks/kcompletion-${KFMIN}:5
+	>=kde-frameworks/kconfig-${KFMIN}:5
+	>=kde-frameworks/kconfigwidgets-${KFMIN}:5
+	>=kde-frameworks/kcoreaddons-${KFMIN}:5
+	>=kde-frameworks/kcrash-${KFMIN}:5
+	>=kde-frameworks/kdeclarative-${KFMIN}:5
+	>=kde-frameworks/kglobalaccel-${KFMIN}:5=
+	>=kde-frameworks/ki18n-${KFMIN}:5
+	>=kde-frameworks/kiconthemes-${KFMIN}:5
+	>=kde-frameworks/kidletime-${KFMIN}:5=
+	>=kde-frameworks/kio-${KFMIN}:5
+	>=kde-frameworks/knewstuff-${KFMIN}:5
+	>=kde-frameworks/knotifications-${KFMIN}:5
+	>=kde-frameworks/kpackage-${KFMIN}:5
+	>=kde-frameworks/kservice-${KFMIN}:5
+	>=kde-frameworks/ktextwidgets-${KFMIN}:5
+	>=kde-frameworks/kwayland-${KFMIN}:5
+	>=kde-frameworks/kwidgetsaddons-${KFMIN}:5
+	>=kde-frameworks/kwindowsystem-${KFMIN}:5[X]
+	>=kde-frameworks/kxmlgui-${KFMIN}:5
+	>=kde-frameworks/plasma-${KFMIN}:5
+	>=kde-plasma/breeze-${PVCUT}:5
+	>=kde-plasma/kdecoration-${PVCUT}:5
+	>=kde-plasma/kscreenlocker-${PVCUT}:5
+	>=kde-plasma/kwayland-server-${PVCUT}:5
+	media-libs/fontconfig
+	media-libs/freetype
+	media-libs/libepoxy
+	media-libs/mesa[egl,gbm,wayland,X(+)]
+	virtual/libudev:=
+	x11-libs/libICE
+	x11-libs/libSM
+	x11-libs/libX11
+	x11-libs/libXi
+	x11-libs/libdrm
+	>=x11-libs/libxcb-1.10
+	>=x11-libs/libxkbcommon-0.7.0
+	x11-libs/xcb-util-cursor
+	x11-libs/xcb-util-image
+	x11-libs/xcb-util-keysyms
+	x11-libs/xcb-util-wm
+	accessibility? ( media-libs/libqaccessibilityclient:5 )
+	caps? ( sys-libs/libcap )
+	gles2-only? ( media-libs/mesa[gles2] )
+	screencast? ( >=media-video/pipewire-0.3:= )
+"
+# TODO: sys-apps/hwdata? not packaged yet; commit 33a1777a, Gentoo-bug 717216
+RDEPEND="${COMMON_DEPEND}
+	>=dev-qt/qtquickcontrols-${QTMIN}:5
+	>=dev-qt/qtquickcontrols2-${QTMIN}:5
+	>=dev-qt/qtvirtualkeyboard-${QTMIN}:5
+	>=kde-frameworks/kirigami-${KFMIN}:5
+	>=kde-frameworks/kitemmodels-${KFMIN}:5[qml]
+	multimedia? ( >=dev-qt/qtmultimedia-${QTMIN}:5[gstreamer,qml] )
+"
+DEPEND="${COMMON_DEPEND}
+	>=dev-qt/designer-${QTMIN}:5
+	>=dev-qt/qtconcurrent-${QTMIN}:5
+	x11-base/xorg-proto
+"
+PDEPEND="
+	>=kde-plasma/kde-cli-tools-${PVCUT}:5
+"
+
+src_prepare() {
+	if use lowlatency; then
+		eapply "${FILESDIR}/${PN}-lowlatency-5.20.5.patch"
+		# these patches don't apply cleanly when lowlatency is used, so we need slighly different ones
+		eapply "${FILESDIR}/${PN}-lowlatency-5.20.5-revert-new-focuschain-w-minimised.patch" # KDE-Bug 427840
+		eapply "${FILESDIR}/${PN}-lowlatency-5.20.5-keep-focuschain-behavior-w-minimised.patch" # Plasma/5.21
+	else
+		eapply "${FILESDIR}/${P}-revert-new-focuschain-w-minimised.patch" # KDE-Bug 427840
+		eapply "${FILESDIR}/${P}-keep-focuschain-behavior-w-minimised.patch" # Plasma/5.21
+	fi
+	ecm_src_prepare
+	use multimedia || eapply "${FILESDIR}/${PN}-5.16.80-gstreamer-optional.patch"
+
+	# TODO: try to get a build switch upstreamed
+	if ! use screencast; then
+		sed -e "s/^pkg_check_modules.*PipeWire/#&/" \
+			-i CMakeLists.txt || die
+	fi
+}
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake_use_find_package accessibility QAccessibilityClient)
+		$(cmake_use_find_package caps Libcap)
+	)
+
+	ecm_src_configure
+}
+
+pkg_postinst() {
+	ecm_pkg_postinst
+	elog "In Plasma 5.20, default behavior of the Task Switcher to move minimised"
+	elog "windows to the end of the list was changed so that it remains in the"
+	elog "original order. To revert to the well established behavior:"
+	elog
+	elog " - Edit ~/.config/kwinrc"
+	elog " - Find [TabBox] section"
+	elog " - Add \"MoveMinimizedWindowsToEndOfTabBoxFocusChain=true\""
+}


### PR DESCRIPTION
The added patches and changes to the ebuild were taken from portage's -r1, see commit [7a33893e](https://github.com/gentoo/gentoo/commit/7a33893e31a976960a6d96d81d6f89e9a8b2365a). As they don't apply cleanly when the `lowlatency` USE flag is used, I had to provide an adapted version of them.

Still, users are free to use or not use lowlatency on this ebuild and still get the -r1 changes. All four combinations (lowlatency on/off, minimizing moves window to last task switcher) compile and work fine on my end.

Come to think of it, I could've also updated the lowlatency patch with the -r1 changes pre-applied and just not have the individual patches in this repository. Hindsight is 20:20, I guess.